### PR TITLE
I purpose less awk because it hurts my brain

### DIFF
--- a/Engine/RancherOS/cloud-config.yml
+++ b/Engine/RancherOS/cloud-config.yml
@@ -44,7 +44,8 @@ runcmd:
 #- echo 'docker run --rm radial/busyboxplus:curl curl $@' > /usr/bin/curl && chmod +x /usr/bin/curl
 # Helm
 # https://helm.sh/docs/intro/install/
-- wget -P /tmp https://get.helm.sh/helm-`wget https://github.com/helm/helm/releases -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}'`-linux-amd64.tar.gz
+#- wget -P /tmp https://get.helm.sh/helm-`wget https://github.com/helm/helm/releases -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}'`-linux-amd64.tar.gz
+- wget -P /tmp https://get.helm.sh/helm-`wget https://api.github.com/repos/helm/helm/releases/latest -O - | jq '.tag_name' -r`-linux-amd64.tar.gz
 - gunzip /tmp/helm-* && tar -xf /tmp/helm-*.tar -C /tmp && mv /tmp/linux-amd64/helm /usr/bin/helm
 # Kubernetes
 # https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-linux


### PR DESCRIPTION
You can replace this: 
`wget https://github.com/helm/helm/releases -O - 2>&1 | grep 'href="/helm/helm/releases/tag/v3.' | grep -v no-underline | head -n 1 | cut -d '"' -f 2 | awk '{n=split($NF,a,"/");print a[n]}' | awk 'a !~ $0{print}; {a=$0}'`

with this:
`wget https://api.github.com/repos/helm/helm/releases/latest -O - | jq '.tag_name' -r`

As long as they don't change their download scheme, this should work for whatever version (I used the powershell equiv of this to get helm releases since 2.x)